### PR TITLE
Brought assets.json more in line with uBO's assets

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -694,15 +694,15 @@
     "contentURL": "https://raw.githubusercontent.com/lassekongo83/Frellwits-filter-lists/master/Frellwits-Swedish-Filter.txt",
     "supportURL": "https://github.com/lassekongo83/Frellwits-filter-lists"
   },
-	"THA-0": {
-		"content": "filters",
-		"group": "regions",
-		"off": true,
-		"title": "THA: EasyList Thailand",
-		"lang": "th",
-		"contentURL": "https://raw.githubusercontent.com/easylist-thailand/easylist-thailand/master/subscription/easylist-thailand.txt",
-		"supportURL": "https://github.com/easylist-thailand/easylist-thailand"
-	},
+  "THA-0": {
+     "content": "filters",
+     "group": "regions",
+     "off": true,
+     "title": "THA: EasyList Thailand",
+     "lang": "th",
+     "contentURL": "https://raw.githubusercontent.com/easylist-thailand/easylist-thailand/master/subscription/easylist-thailand.txt",
+     "supportURL": "https://github.com/easylist-thailand/easylist-thailand"
+  },
   "TUR-0": {
     "content": "filters",
     "group": "regions",

--- a/assets/assets.json
+++ b/assets/assets.json
@@ -12,6 +12,7 @@
     "updateAfter": 14,
     "contentURL": [
       "https://publicsuffix.org/list/public_suffix_list.dat",
+      "https://cdn.rawgit.com/publicsuffix/list/master/public_suffix_list.dat",
       "assets/ThirdParty/PublicSuffix.dat"
     ]
   },
@@ -327,8 +328,8 @@
     "updateAfter": 5,
     "off": true,
     "title": "Dan Pollock’s hosts file",
-    "contentURL": "http://someonewhocares.org/hosts/hosts",
-    "supportURL": "http://someonewhocares.org/hosts/"
+    "contentURL": "https://someonewhocares.org/hosts/hosts",
+    "supportURL": "https://someonewhocares.org/hosts/"
   },
   "hphosts": {
     "content": "filters",
@@ -584,8 +585,8 @@
     "off": true,
     "title": "LTU: Adblock Plus Lithuania",
     "lang": "lt",
-    "contentURL": "http://margevicius.lt/easylistlithuania.txt",
-    "supportURL": "http://margevicius.lt/easylist_lithuania/"
+    "contentURL": "https://margevicius.lt/easylistlithuania.txt",
+    "supportURL": "https://margevicius.lt/2014/06/26/easylist_lithuania/"
   },
   "LVA-0": {
     "content": "filters",
@@ -693,6 +694,15 @@
     "contentURL": "https://raw.githubusercontent.com/lassekongo83/Frellwits-filter-lists/master/Frellwits-Swedish-Filter.txt",
     "supportURL": "https://github.com/lassekongo83/Frellwits-filter-lists"
   },
+	"THA-0": {
+		"content": "filters",
+		"group": "regions",
+		"off": true,
+		"title": "THA: EasyList Thailand",
+		"lang": "th",
+		"contentURL": "https://raw.githubusercontent.com/easylist-thailand/easylist-thailand/master/subscription/easylist-thailand.txt",
+		"supportURL": "https://github.com/easylist-thailand/easylist-thailand"
+	},
   "TUR-0": {
     "content": "filters",
     "group": "regions",


### PR DESCRIPTION
In light of recent changes to uBO's assets file (https://github.com/uBlockOrigin/uBlock-issues/issues/166, https://github.com/uBlockOrigin/uBlock-issues/issues/193, https://github.com/uBlockOrigin/uBlock-issues/issues/197), and if there's planned any further updates for Nano Adblocker on the NanoCore1 branch, I've made this pull to add those improvements to it. They include updating the Dan Pollock and Lithuanian lists to their HTTPS versions, and to add a new Thai list.

I also have a suggestion for an optional idea that'd admittedly be more "out there":
• Changing *MVPS Hosts*'s link to https://raw.githubusercontent.com/StevenBlack/hosts/master/data/mvps.org/hosts. I know that it's usually heavily discouraged in the adblocking community to primarily use unofficial mirrors, but it'd mean that every single list that is included in Nano Adblocker would've been served over HTTPS.