### PR TITLE
Remove FIN-0 list due to breach of trust

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -446,15 +446,6 @@
     "contentURL": "https://adblock.ee/list.php",
     "supportURL": "https://adblock.ee/"
   },
-  "FIN-0": {
-    "content": "filters",
-    "group": "regions",
-    "off": true,
-    "title": "FIN: Finnish Addition to Easylist",
-    "lang": "fi",
-    "contentURL": "https://adb.juvander.net/Finland_adb.txt",
-    "supportURL": "https://www.juvander.fi/AdblockFinland"
-  },
   "FRA-0": {
     "content": "filters",
     "group": "regions",


### PR DESCRIPTION
Background https://github.com/uBlockOrigin/uBlock-issues/issues/285

I agree with the stance of uBlock Origin on the matter. This is a clear breach of trust and that list cannot be trusted again. This sort of abuse of trust should not be accepted by the community.